### PR TITLE
Fix inverse case

### DIFF
--- a/lib/cases.js
+++ b/lib/cases.js
@@ -103,13 +103,14 @@ exports.upper = function (string) {
  */
 
 exports.inverse = function (string) {
-  for (var i = 0, char; char = string[i]; i++) {
+  var chars = string.split('');
+  for (var i = 0, char; char = chars[i]; i++) {
     if (!/[a-z]/i.test(char)) continue;
     var upper = char.toUpperCase();
     var lower = char.toLowerCase();
-    string[i] = char == upper ? lower : upper;
+    chars[i] = char == upper ? lower : upper;
   }
-  return string;
+  return chars.join('');
 };
 
 /**

--- a/test/tests.js
+++ b/test/tests.js
@@ -47,4 +47,10 @@ describe('case', function () {
 
 for (var key in cases) method(key);
 
+describe('#inverse', function () {
+  it('should invert case', function () {
+    assert('tHIS iS A sTRING' == kase.inverse('This Is a String'));
+  });
+});
+
 });


### PR DESCRIPTION
JavaScript strings are immutable, so inverse code does not work.

```js
> to.inverse('whaT tHe HeCK')
'whaT tHe HeCK'
```

This patch fixes that.