### PR TITLE
Fix spelling of 'repository'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "to-case",
-  "repoistory": "git://github.com/ianstormtaylor/to-case.git",
+  "repository": "git://github.com/ianstormtaylor/to-case.git",
   "license": "MIT",
   "version": "1.0.1",
   "description": "Simple case conversion and detection for strings.",


### PR DESCRIPTION
I'm unable to click from the [npm package](https://www.npmjs.com/package/to-case) to github, because this property name was misspelled.